### PR TITLE
MCM sync priority annotations for scaling

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -775,13 +775,14 @@ func (s ActiveMachines) Less(i, j int) bool {
 	// machinePriority annotation.
 	// Case-2: If both priorities are equal, then we look at their machinePhase
 	// and prioritize as mentioned in the above map
-	// Case-3: If both Case-1 & Case-2 is false, we prioritize based on creation time
+	// Case-3: If both Case-1 & Case-2 is false, we prioritize based on creation time, new node will be scaled-in first
 	if machineIPriority != machineJPriority {
 		return machineIPriority < machineJPriority
 	} else if m[s[i].Status.CurrentStatus.Phase] != m[s[j].Status.CurrentStatus.Phase] {
 		return m[s[i].Status.CurrentStatus.Phase] < m[s[j].Status.CurrentStatus.Phase]
 	} else if s[i].CreationTimestamp != s[j].CreationTimestamp {
-		return s[i].CreationTimestamp.Before(&s[j].CreationTimestamp)
+		// scale new node first
+		return s[j].CreationTimestamp.Before(&s[i].CreationTimestamp)
 	}
 
 	return false

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -196,7 +196,7 @@ var _ = Describe("#controllerUtils", func() {
 			sortedMachinesInOrderOfPhase[0].DeepCopy(),
 		}
 
-		sortedMachinesInOrderOfCreationTimeStamp := newMachines(3, &machinev1.MachineTemplateSpec{
+		machineCreatedOrder := newMachines(3, &machinev1.MachineTemplateSpec{
 			ObjectMeta: *newObjectMeta(objMeta, 0),
 			Spec: machinev1.MachineSpec{
 				Class: machinev1.ClassSpec{
@@ -205,10 +205,15 @@ var _ = Describe("#controllerUtils", func() {
 				},
 			},
 		}, nil, nil, nil, nil)
+		sortedMachinesInDescOrderOfCreationTimeStamp := []*machinev1.Machine{
+			machineCreatedOrder[2].DeepCopy(),
+			machineCreatedOrder[1].DeepCopy(),
+			machineCreatedOrder[0].DeepCopy(),
+		}
 		unsortedMachinesInOrderOfCreationTimeStamp := []*machinev1.Machine{
-			sortedMachinesInOrderOfCreationTimeStamp[1].DeepCopy(),
-			sortedMachinesInOrderOfCreationTimeStamp[0].DeepCopy(),
-			sortedMachinesInOrderOfCreationTimeStamp[2].DeepCopy(),
+			machineCreatedOrder[1].DeepCopy(),
+			machineCreatedOrder[0].DeepCopy(),
+			machineCreatedOrder[2].DeepCopy(),
 		}
 
 		DescribeTable("###sort",
@@ -227,7 +232,7 @@ var _ = Describe("#controllerUtils", func() {
 			}),
 			Entry("sort on creation timestamp", &data{
 				inputMachines:  unsortedMachinesInOrderOfCreationTimeStamp,
-				outputMachines: sortedMachinesInOrderOfCreationTimeStamp,
+				outputMachines: sortedMachinesInDescOrderOfCreationTimeStamp,
 			}),
 		)
 	})


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What this PR does / why we need it**:
Scaling order is important for stateful workloads, the current scaling strategy has two problems:
1. by default, the eldest node will be scaled-in first, which is not suitable for statefulset
2. priority can only be controlled via `Machine` CR, the client must access Seed to do so, which expose too much implementation details.

**Which issue(s) this PR fixes**:
1. scale newest node first if other priority conditions are same
2. priority annotation can now also be added to the `Node` object

TEST=`make test`
